### PR TITLE
Whitespace and sort order for Dumper Middleware

### DIFF
--- a/lib/schema_plus/enums/middleware.rb
+++ b/lib/schema_plus/enums/middleware.rb
@@ -7,12 +7,12 @@ module SchemaPlus::Enums
         module Postgresql
 
           def after(env)
-            env.connection.enums.each do |schema, name, values|
+            env.connection.enums.sort_by {|k| k[1] }.each do |schema, name, values|
               params = [name.inspect]
               params << values.map(&:inspect).join(', ')
               params << ":schema => #{schema.inspect}" if schema != 'public'
 
-              env.initial << "create_enum #{params.join(', ')}"
+              env.initial << "  create_enum #{params.join(', ')}"
             end
           end
         end


### PR DESCRIPTION
Currently the `schema_plus_enum` dumper will dump in the following format: 

``` rb
ActiveRecord::Schema.define(version: 0) do

  # These are extensions that must be enabled in order to support this database
  enable_extension "plpgsql"


create_enum "color", "cyan", "magenta", "yellow", "black", :schema => "cmyk"
create_enum "aaaa", "1", "2", "3"
create_enum "bar", "1", "2", "3"
create_enum "color", "cyan", "magenta", "yellow", "black"
create_enum "foo", "foo", "FOO", "bar"
  create_table "test", force: :cascade do |t|
    t.integer "col1"
  end

end

```

Correctly I think this should look like so, where schema being visually represented as a secondary key should perhaps also be first ordered by `enum_name` as a they key - (not sure about this one). 

Will update and add some additional specs if this looks sensible. 
